### PR TITLE
Console now resizes if window is resized while open

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ function love.textinput(t)
 	-- [Receive text input and pass it on to the console.]
 	console.textinput(t)
 end
+
+function love.resize(w, h)
+	-- [Resize the console if the window is resized.]
+end
 ```
 
 From there on you can run your application as your normally would. At this point while your application is running you can hit *F10* to bring up the console. This can be done assuming you are using the default key bindings and have not made any changes to the configuration file as explained in the next section. If you've gotten this far your console is pretty much ready to be used. If you want to take it even further you should check out the next section.

--- a/loveconsole/init.lua
+++ b/loveconsole/init.lua
@@ -478,6 +478,11 @@ function console.textinput(s)
 	end
 end
 
+-- If the window is resized whilst the console is open, resize the console.
+function console.resize(w, h)
+	screenWidth, screenHeight = w, h
+end
+
 -- Execute the configuration file and initialize user consoleCommands.
 local loaded, data
 loaded, data = pcall(love.filesystem.load, scriptPath() .."config.lua")

--- a/main.lua
+++ b/main.lua
@@ -36,3 +36,7 @@ end
 function love.textinput(t)
 	console.textinput(t) -- Send text input to the console.
 end
+
+function love.resize(w, h)
+	console.resize(w, h) -- Resize the console if the window is resized.
+end


### PR DESCRIPTION
Console would originally stay the same size after a window resize whilst the console is open.
I added `console.resize(w, h)` to fix this, and must be called in `love.resize(w, h)`
