### PR TITLE
Added option to print to console with default print

### DIFF
--- a/loveconsole/config.lua
+++ b/loveconsole/config.lua
@@ -20,6 +20,7 @@ config.consoleMarginTop = 0 -- Top border margin of the console text.
 config.lineSpacing = 4 -- Space between individual lines.
 config.outlineSize = 1 -- Outline height at the bottom of the console.
 config.ignoreToggleKey = false -- If true, the toggle key will not be inputted to the console's input field.
+config.displayPrint = false -- If true the default print function will print to the console.
 
 config.stackMax = 100  -- Maximum number of lines stored in the console stack before old lines are removed.
 config.sizeMin = 5 -- Minimum lines the console should display before extending to the max size.

--- a/loveconsole/init.lua
+++ b/loveconsole/init.lua
@@ -41,6 +41,8 @@ local warningCount, errorCount = 0, 0 -- Track the number of unchecked errors an
 
 local screenWidth, screenHeight = love.graphics.getDimensions() -- Store the screen size.
 
+local defaultPrint = print
+
 -- Returns the current lua local path to this script.
 local function scriptPath()
    local str = debug.getinfo(2, "S").source:sub(2)
@@ -178,7 +180,7 @@ function console.success(message)
 	end
 end
 
--- Print a string to the console with error styling  and add to the error count.
+-- Print a string to the console with error styling and add to the error count.
 function console.error(message)
 	if config.enabled then
 		if message ~= nil then
@@ -187,6 +189,14 @@ function console.error(message)
 		else
 			stackpush("Please supply a value before sending an error message to the console.", "warning")
 		end
+	end
+end
+
+-- Print a string to the console using the default print function.
+function print(...)
+	defaultPrint(...)
+	if config.displayPrint then
+		console.print(...)
 	end
 end
 


### PR DESCRIPTION
If the option is true, calling the default `print()` will print to the console.
