### PR TITLE
Reset color and font on error/warning widget

### DIFF
--- a/loveconsole/init.lua
+++ b/loveconsole/init.lua
@@ -368,6 +368,7 @@ function console.draw()
 
 			-- Reset color.
 			love.graphics.setColor(255, 255, 255, 255)
+			love.graphics.setFont(baseFont)
 		end
 	end
 end

--- a/loveconsole/init.lua
+++ b/loveconsole/init.lua
@@ -365,6 +365,9 @@ function console.draw()
 			-- Draw the error count.
 			love.graphics.setColor(config.colors["error"].r, config.colors["error"].g, config.colors["error"].b, config.colors["error"].a)
 			love.graphics.printf(math.min(9999, errorCount), width + config.outlineSize - (width / 5 + config.fontSize / 2), config.outlineSize + (config.fontSize / 6), 2, "center")
+
+			-- Reset color.
+			love.graphics.setColor(255, 255, 255, 255)
 		end
 	end
 end


### PR DESCRIPTION
Fixed the widget not resetting the color and font after drawing.
